### PR TITLE
Fix: address compiler errors related to type constraints

### DIFF
--- a/FractalSharp.Algorithms/Fractals/SquareMandelbrotAlgorithm.cs
+++ b/FractalSharp.Algorithms/Fractals/SquareMandelbrotAlgorithm.cs
@@ -26,7 +26,7 @@ namespace FractalSharp.Algorithms.Fractals
     public class SquareMandelbrotAlgorithm<TNumber, TConverter> :
         IAlgorithmProvider<Complex<TNumber>, PointData<double>, SpecializedValue<int>>,
         IFractalProvider<EscapeTimeParams<TNumber>, TNumber>
-        where TNumber : unmanaged, INumber<TNumber>
+        where TNumber : unmanaged, IFloatingPointIeee754<TNumber>
         where TConverter : struct, INumberConverter<TNumber>
     {
         private static readonly TNumber _two = TNumber.One + TNumber.One;

--- a/FractalSharp/Algorithms/FractalProvider.cs
+++ b/FractalSharp/Algorithms/FractalProvider.cs
@@ -24,7 +24,7 @@ namespace FractalSharp.Algorithms
     public interface IFractalProvider<TParams, TNumber>
         : IAlgorithmProvider<Complex<TNumber>, PointData<double>, TParams>
         where TParams : struct
-        where TNumber : struct, INumber<TNumber>
+        where TNumber : struct, IFloatingPointIeee754<TNumber>
     {
         static abstract Rectangle<TNumber> GetOutputBounds(TParams @params, TNumber aspectRatio);
     }

--- a/FractalSharp/Algorithms/Fractals/EscapeTimeParams.cs
+++ b/FractalSharp/Algorithms/Fractals/EscapeTimeParams.cs
@@ -23,7 +23,7 @@ using System.Numerics;
 namespace FractalSharp.Algorithms.Fractals
 {
     public struct EscapeTimeParams<TNumber>
-        where TNumber : struct, INumber<TNumber>
+        where TNumber : struct, IFloatingPointIeee754<TNumber>
     {
         public int MaxIterations { get; set; }
         public Complex<TNumber> Position { get; set; }

--- a/FractalSharp/Algorithms/PointData.cs
+++ b/FractalSharp/Algorithms/PointData.cs
@@ -28,7 +28,7 @@ namespace FractalSharp.Algorithms
     }
 
     public struct PointData<TNumber>
-        where TNumber : struct, INumber<TNumber>
+        where TNumber : struct, IFloatingPointIeee754<TNumber>
     {
         public Complex<TNumber> ZValue { get; }
         public int IterCount { get; }

--- a/FractalSharp/Processing/FractalProcessor.cs
+++ b/FractalSharp/Processing/FractalProcessor.cs
@@ -29,7 +29,7 @@ namespace FractalSharp.Processing
         : BaseProcessor<Complex<TNumber>, PointData<double>, TAlgorithm, TParams>
         where TAlgorithm : IFractalProvider<TParams, TNumber>
         where TParams : struct
-        where TNumber : struct, INumber<TNumber>
+        where TNumber : struct, IFloatingPointIeee754<TNumber>
     {
         protected PointMapper<TNumber> pointMapper;
 

--- a/FractalSharp/Processing/GPUFractalProcessor.cs
+++ b/FractalSharp/Processing/GPUFractalProcessor.cs
@@ -31,7 +31,7 @@ namespace FractalSharp.Processing
         where TAlgorithm :
             IFractalProvider<EscapeTimeParams<TNumber>, TNumber>,
             IAlgorithmProvider<Complex<TNumber>, PointData<double>, SpecializedValue<int>>
-        where TNumber : unmanaged, INumber<TNumber>
+        where TNumber : unmanaged, IFloatingPointIeee754<TNumber>
     {
         private static void FractalKernel(Index2D idx, ArrayView2D<Complex<TNumber>, Stride2D.DenseY> inputBuff, ArrayView2D<PointData<double>, Stride2D.DenseY> outputBuff, SpecializedValue<int> maxIterations)
         {


### PR DESCRIPTION
This PR fixes several compiler errors caused by the new type constraint, making sure that all erroneous instances are now consistent with the change. 